### PR TITLE
Fix #5, Update Travis config for Py2.5/argparse

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,13 +35,23 @@ matrix:
     # Because Travis-CI no longer offers the 2.5 environment by default,
     # we'll manually install 2.5.... It's not even available on the common
     # ubuntu repos, so we'll use the well-known deadsnakes repo.
+    #
+    # Also, using ideas from @kura in https://gist.github.com/kura/8517802 ,
+    # download and install a compatible version of easy_install,
+    # which gives us an old version of pip,
+    # which gives us argparse which our unit test framework requires.
     - language: python
       os: linux
       env: Python='2.5' PythonBin="/usr/bin/python2.5"
       install:
         sudo add-apt-repository "ppa:fkrull/deadsnakes" -y;
         sudo apt-get update;
-        sudo apt-get install python2.5;
+        sudo apt-get install python2.5 ;
+        wget https://raw.githubusercontent.com/pypa/setuptools/bootstrap-py24/ez_setup.py -O /tmp/ez_setup.py ;
+        sudo $PythonBin /tmp/ez_setup.py ;
+        sudo easy_install-2.5 pip==1.3.1 ;
+        pip-2.5 --version ;
+        sudo pip-2.5 install --insecure argparse ;
 
     # OS X Instances follow
     # There is no OS X + PYTHON combination available by default, so we
@@ -84,4 +94,3 @@ script:
   - $PythonBin build.py -t;
   - cd ../RUNNABLE;
   - $PythonBin utf.py -a;
-


### PR DESCRIPTION
This commit updates the Travis configuration so that the `argparse` module is made available for tests on Python 2.5.

The big challenge for this fix was to ensure we get the proper (i.e. compatible) versions for `easy_install` and `pip` both installed and executed correctly. We found a starting point in @kura's https://gist.github.com/kura/8517802 (thanks!); from there, the tools' docs and error messages guided the way forward.

Note how `pip-2.5` is used (analoguos to `python2.5`), and that we let `pip` download in  `--insecure` mode. The latter is done as it's simpler than downloading into the correct `site-packages` dir (without support from `pip`) and installing a backported SSL from https://pypi.python.org/pypi/ssl/ manually. See below for the traceback (triggered by running without `--insecure`) that suggested these two options.

-----

Exception:
Traceback (most recent call last):
  File "/usr/lib/python2.5/site-packages/pip-1.3.1-py2.5.egg/pip/basecommand.py", line 139, in main
    status = self.run(options, args)
  File "/usr/lib/python2.5/site-packages/pip-1.3.1-py2.5.egg/pip/commands/install.py", line 266, in run
    requirement_set.prepare_files(finder, force_root_egg_info=self.bundle, bundle=self.bundle)
  File "/usr/lib/python2.5/site-packages/pip-1.3.1-py2.5.egg/pip/req.py", line 1026, in prepare_files
    url = finder.find_requirement(req_to_install, upgrade=self.upgrade)
  File "/usr/lib/python2.5/site-packages/pip-1.3.1-py2.5.egg/pip/index.py", line 125, in find_requirement
    page = self._get_page(main_index_url, req)
  File "/usr/lib/python2.5/site-packages/pip-1.3.1-py2.5.egg/pip/index.py", line 353, in _get_page
    return HTMLPage.get_page(link, req, cache=self.cache)
  File "/usr/lib/python2.5/site-packages/pip-1.3.1-py2.5.egg/pip/index.py", line 471, in get_page
    resp = urlopen(url)
  File "/usr/lib/python2.5/site-packages/pip-1.3.1-py2.5.egg/pip/download.py", line 143, in __call__
    response = self.get_opener(scheme=scheme).open(url)
  File "/usr/lib/python2.5/site-packages/pip-1.3.1-py2.5.egg/pip/download.py", line 201, in get_opener
    raise NoSSLError()
NoSSLError:

You don't have an importable ssl module. You are most        ##
likely using Python 2.5, which did not include ssl           ##
support by default. In this state, we can not provide        ##
ssl certified downloads from PyPI.                           ##

You can do one of 2 things:                                  ##
 1) Install this: https://pypi.python.org/pypi/ssl/          ##
    (It provides ssl support for older Pythons )             ##
 2) Use the --insecure option to allow this insecurity       ##

For more details, go to the  "SSL Certificate Verification"  ##
section located here:                                        ##
   http://www.pip-installer.org/en/latest/logic.html         ##